### PR TITLE
make floating health work with big overheal values

### DIFF
--- a/resource/ui/healthiconpanel.res
+++ b/resource/ui/healthiconpanel.res
@@ -8,7 +8,7 @@
 		"xpos_minmode"								"0"
 		"ypos"										"0"
 		"ypos_minmode"								"0"
-		"wide"										"26"
+		"wide"										"60"
 		"tall"										"25"
 		"visible"									"1"
 		"enabled"									"1"
@@ -33,22 +33,40 @@
 		"TFFont"									"ProductBold14"
 		"TextColor"									"HudOffWhite"
 		"autoResize"								"1"
-	}
+
+	// silly lil hack
 	
-	"HealthBG"
+	"PlayerStatusHealthValueMain2"
 	{
-		"ControlName"		"EditablePanel"
-		"fieldName"			"HealthBG"
-		"xpos"  "0"
-		"ypos"  "0"
-		"zpos"			"0"
-		"wide"  "40"
-		"tall"  "20"
-		"visible"       "1"           
-		"enabled"       "1"
-		"paintbackground"      "1"
-		"paintbackgroundtype"  "0"
-		"bgcolor_override"     "0 0 0 200"
+		"ControlName"		"Label"
+		"fieldName"		"PlayerStatusHealthValueMain2"
+		"xpos"			"0"
+		"ypos"			"-1"
+		"zpos"			"8"
+		"wide"			"60"
+		"tall"			"17"
+		"visible"		"1"
+		"enabled"		"1"
+		"labeltext"		"%Health%"
+		"font"			"ProductSemiBold16"
+		"textAlignment"		"center"
+		"fgcolor_override"		"220 220 220 255"
 	}
-	
+	"PlayerStatusHealthValueMain2Shadow"
+	{
+		"ControlName"		"Label"
+		"fieldName"		"PlayerStatusHealthValueMain2Shadow"
+		"xpos"			"1"
+		"ypos"			"0"
+		"zpos"			"8"
+		"wide"			"60"
+		"tall"			"17"
+		"visible"		"1"
+		"enabled"		"1"
+		"labeltext"		"%Health%"
+		"font"			"ProductSemiBold16"
+		"textAlignment"		"center"
+		"fgcolor_override"		"0 0 0 255"
+	}
+	}
 }


### PR DESCRIPTION
makes the floating health panel able to display higher health values. unfortunately this comes at the cost of removing the background unless you know a way of making it dynamically fit the health.